### PR TITLE
Add summary/confirmation screen to form wizard

### DIFF
--- a/docs/src/how-to-guides/create-renderer.md
+++ b/docs/src/how-to-guides/create-renderer.md
@@ -135,6 +135,45 @@ class MyRenderer(BaseRenderer):
                 return [options[int(p) - 1]["const"] for p in parts]
 ```
 
+## Add a summary/confirmation screen
+
+When users call `renderer.render(confirm=True)`, the pipeline calls
+`render_summary(user_answers)` after all questions are answered.
+The default implementation (inherited from `BaseRenderer`) prints a plain-text
+list and prompts for confirmation.
+
+Override `render_summary` in your subclass to provide a richer presentation:
+
+```python
+from typing import Any
+
+class MyRenderer(BaseRenderer):
+    ...
+
+    def render_summary(self, user_answers: dict[str, Any]) -> bool:
+        print("\n=== Review your answers ===")
+        for key, value in user_answers.items():
+            question = self._question_for_key(key)
+            title = question.title if question else key
+            display = self._summary_display_value(question, value)
+            print(f"  {title}: {display}")
+        print()
+        while True:
+            response = input("Confirm? [Y/n]: ").strip().lower()
+            if not response or response in ("y", "yes"):
+                return True
+            if response in ("n", "no"):
+                return False
+            print("  Please enter y or n.")
+```
+
+Return `True` to accept the answers and let `render()` return them.
+Return `False` to restart the form; the current answers become the defaults so
+the user can change only what they want.
+
+If you do not need a summary screen, you can skip this step—the default
+implementation in `BaseRenderer` is already functional.
+
 ## Register the renderer as an entry point
 
 TUI Forms discovers renderers through Python {term}`entry point`s in the `tui_forms.renderers` group.

--- a/docs/src/reference/base-renderer.md
+++ b/docs/src/reference/base-renderer.md
@@ -4,7 +4,7 @@ myst:
     "description": "API reference for BaseRenderer—the abstract base class that all TUI Forms renderer backends extend."
     "property=og:description": "API reference for BaseRenderer—the abstract base class that all TUI Forms renderer backends extend."
     "property=og:title": "BaseRenderer reference"
-    "keywords": "tui-forms, reference, BaseRenderer, API, renderer, abstract, _ask_string, _ask_boolean, _ask_choice, _ask_multiple, back navigation, go back"
+    "keywords": "tui-forms, reference, BaseRenderer, API, renderer, abstract, _ask_string, _ask_boolean, _ask_choice, _ask_multiple, back navigation, go back, summary, confirm"
 ---
 
 # BaseRenderer
@@ -49,7 +49,12 @@ You do not normally call this directly—use {func}`tui_forms.create_renderer` i
 ### `render`
 
 ```python
-def render(self, initial_answers: dict[str, Any] | None = None) -> dict[str, Any]
+def render(
+    self,
+    initial_answers: dict[str, Any] | None = None,
+    *,
+    confirm: bool = False,
+) -> dict[str, Any]
 ```
 
 Run the form and return the collected answers.
@@ -57,6 +62,7 @@ Run the form and return the collected answers.
 | Parameter | Type | Description |
 |---|---|---|
 | `initial_answers` | `dict \| None` | Optional pre-populated answers that take priority over schema defaults. Pass the dict exactly as returned by a previous `render()` call (`root_key` nesting included, when applicable). When `None`, schema defaults are used for all questions. |
+| `confirm` | `bool` | When `True`, display a summary screen after all questions are answered and ask the user to confirm. If the user declines, the form restarts with the current answers pre-populated as defaults. Default: `False`. |
 
 Calls the abstract methods in order as the user progresses through the form.
 After all user-facing questions are answered, resolves hidden fields automatically.
@@ -212,6 +218,49 @@ Called automatically by the rendering pipeline before re-prompting the question.
 ---
 
 ## Overridable methods
+
+### `render_summary`
+
+```python
+def render_summary(self, user_answers: dict[str, Any]) -> bool
+```
+
+Display a summary of the user-provided answers and ask for confirmation.
+Called by `render()` when `confirm=True`.
+
+The default implementation prints a plain-text list to standard output and
+prompts the user to confirm (`y`) or restart (`n`).
+Pressing **Enter** without typing anything accepts the answers (default yes).
+Override this method in a subclass for a richer presentation (for example, a
+styled table).
+
+| Parameter | Type | Description |
+|---|---|---|
+| `user_answers` | `dict[str, Any]` | Answers actively provided by the user, as returned by `form.user_answers`. Does not include hidden computed fields. |
+
+**Returns:** `True` to proceed with the collected answers, `False` to restart
+the form with the current answers pre-populated as defaults.
+
+The base implementation uses two helper methods you can also call in your own override:
+
+- `_question_for_key(key)`: returns the `BaseQuestion` for a given key, or `None`.
+- `_summary_display_value(question, value)`: formats a value for display.
+  Boolean values become `"Yes"` or `"No"`, choice and multiple-choice values are
+  resolved to their option titles, and all other values are converted with `str()`.
+
+```python
+# Minimal override example
+def render_summary(self, user_answers: dict[str, Any]) -> bool:
+    print("\nYour answers:")
+    for key, value in user_answers.items():
+        question = self._question_for_key(key)
+        title = question.title if question else key
+        display = self._summary_display_value(question, value)
+        print(f"  {title}: {display}")
+    return input("\nProceed? [Y/n]: ").strip().lower() in ("", "y", "yes")
+```
+
+---
 
 ### `_format_prefix`
 

--- a/docs/src/tutorials/your-first-form.md
+++ b/docs/src/tutorials/your-first-form.md
@@ -163,5 +163,6 @@ After the last question the script prints the collected answers:
 
 - Store the schema in a JSON file and load it with `json.loads(Path("form.json").read_text())`.
 - Try the `rich` renderer for styled prompts: `create_renderer("rich", schema)` (requires `pip install "tui-forms[rich]"`).
+- Pass `confirm=True` to `render()` to show a summary screen after the last question, letting the user review and confirm (or restart with their previous answers as defaults): `renderer.render(confirm=True)`.
 - {doc}`conditional-questions`: show extra questions only when a previous answer matches a specific value.
 - {doc}`/reference/jsonschema-support`: full reference for all supported schema constructs.

--- a/news/9.feature
+++ b/news/9.feature
@@ -1,0 +1,1 @@
+Added a summary/confirmation screen to the form wizard. Pass `confirm=True` to `render()` to display answers before finishing; the user can confirm or restart with prior answers pre-populated. @ericof

--- a/src/tui_forms/demo/__main__.py
+++ b/src/tui_forms/demo/__main__.py
@@ -18,6 +18,7 @@ def run_demo(
     renderer: str,
     schema_name: str = "distribution",
     root_key: str = "",
+    confirm: bool = False,
 ) -> dict[str, Any]:
     """Run the demo form using the named renderer.
 
@@ -27,12 +28,14 @@ def run_demo(
     :param renderer: Name of the renderer to use (e.g. ``"stdlib"``, ``"rich"``).
     :param schema_name: Name of the schema file (without .json extension) to load.
     :param root_key: Optional root key to nest all answers under in the final dict.
+    :param confirm: When ``True``, show a summary/confirmation screen after all
+        questions are answered.
     :return: The answers dict collected from the user.
     """
     schema_file = _get_schema(schema_name)
     schema = json.loads(schema_file.read_text())
     r = create_renderer(renderer, schema, root_key=root_key)
-    answers = r.render()
+    answers = r.render(confirm=confirm)
     print("\n--- Collected answers ---")
     for key, value in answers.items():
         print(f"  {key}: {value!r}")
@@ -44,14 +47,16 @@ def main() -> None:
     renderer_name = "stdlib"
     schema_name = "distribution"
     root_key = ""
-    if len(sys.argv) > 1:
-        renderer_name = sys.argv[1]
-    if len(sys.argv) > 2:
-        schema_name = sys.argv[2]
+    confirm = "--no-confirm" not in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--no-confirm"]
+    if len(args) > 0:
+        renderer_name = args[0]
+    if len(args) > 1:
+        schema_name = args[1]
     if schema_name == "cookieplone":
         root_key = "cookiecutter"
     try:
-        run_demo(renderer_name, schema_name, root_key=root_key)
+        run_demo(renderer_name, schema_name, root_key=root_key, confirm=confirm)
     except ValueError as e:
         print(e)
         sys.exit(1)

--- a/src/tui_forms/renderer/base.py
+++ b/src/tui_forms/renderer/base.py
@@ -43,27 +43,108 @@ class BaseRenderer(ABC):
         self._form = frm
         self._env: Environment = create_environment(config, extensions=extensions)
 
-    def render(self, initial_answers: dict[str, Any] | None = None) -> dict[str, Any]:
+    def render(
+        self,
+        initial_answers: dict[str, Any] | None = None,
+        *,
+        confirm: bool = False,
+    ) -> dict[str, Any]:
         """Render the form and return the collected answers.
+
+        When *confirm* is ``True``, :meth:`render_summary` is called after all
+        questions are answered.  If the user declines to proceed, the form
+        restarts with the previous answers pre-populated as defaults.
 
         :param initial_answers: Optional pre-populated answers that take priority
             over schema defaults. Pass the dict exactly as returned by a previous
             ``render()`` call (root_key nesting included, when applicable).
+        :param confirm: When ``True``, display a summary screen after all
+            questions are answered and ask the user to confirm before returning.
         :return: A flat dict mapping each question key to its answer.
         """
-        self._form.start()
-        if initial_answers:
-            self._form.answers.update(initial_answers)
-        self._ask_questions(self._form.questions)
+        current_initial = initial_answers
+        while True:
+            self._form.start()
+            if current_initial:
+                self._form.answers.update(current_initial)
+            self._ask_questions(self._form.questions)
+            for question in self._form.iter_all():
+                if question.hidden and self._form.is_active(question):
+                    self._form.record(
+                        question.key,
+                        question.default_value(
+                            self._env, self._form.answers, self._form.root_key
+                        ),
+                    )
+            answers = dict(self._form.answers)
+            if not confirm or self.render_summary(self._form.user_answers):
+                return answers
+            current_initial = answers
+
+    def render_summary(self, user_answers: dict[str, Any]) -> bool:
+        """Display a summary of user-provided answers and ask for confirmation.
+
+        Called by :meth:`render` when *confirm* is ``True``.  The default
+        implementation prints a plain-text list and prompts the user to
+        confirm or restart.  Override in a subclass for a richer presentation.
+
+        :param user_answers: Answers actively provided by the user (as returned
+            by ``form.user_answers``).
+        :return: ``True`` to proceed with the collected answers, ``False`` to
+            restart the form with the current answers pre-populated as defaults.
+        """
+        print("\nReview your answers:\n")
+        for key, value in user_answers.items():
+            question = self._question_for_key(key)
+            title = question.title if question else key
+            display = self._summary_display_value(question, value)
+            print(f"  {title}: {display}")
+        print()
+        while True:
+            response = input("Proceed? [Y/n]: ").strip().lower()
+            if not response or response in ("y", "yes"):
+                return True
+            if response in ("n", "no"):
+                return False
+            print("  Please enter y or n.")
+
+    def _question_for_key(self, key: str) -> form.BaseQuestion | None:
+        """Return the question with the given key, or ``None`` if not found.
+
+        :param key: The question key to look up.
+        :return: The matching ``BaseQuestion``, or ``None``.
+        """
         for question in self._form.iter_all():
-            if question.hidden and self._form.is_active(question):
-                self._form.record(
-                    question.key,
-                    question.default_value(
-                        self._env, self._form.answers, self._form.root_key
-                    ),
-                )
-        return dict(self._form.answers)
+            if question.key == key:
+                return question
+        return None
+
+    def _summary_display_value(
+        self, question: form.BaseQuestion | None, value: Any
+    ) -> str:
+        """Return a human-readable string representation of *value* for the summary.
+
+        Booleans are shown as ``Yes`` or ``No``.  Choice and multiple-choice
+        values are resolved to their option titles.  All other values are
+        converted with ``str()``.
+
+        :param question: The question the value belongs to, or ``None``.
+        :param value: The answer value to format.
+        :return: A display string suitable for a summary row.
+        """
+        if question is None:
+            return str(value) if value is not None else ""
+        if isinstance(question, form.QuestionBoolean):
+            return "Yes" if value else "No"
+        if (
+            isinstance(question, (form.QuestionChoice, form.QuestionMultiple))
+            and question.options
+        ):
+            options_map = {opt["const"]: opt["title"] for opt in question.options}
+            if isinstance(value, list):
+                return ", ".join(options_map.get(v, str(v)) for v in value)
+            return options_map.get(value, str(value))
+        return str(value) if value is not None else ""
 
     def _format_prefix(self, current: int, total: int) -> str:
         """Return the prefix string shown before each question title.

--- a/src/tui_forms/renderer/cookiecutter.py
+++ b/src/tui_forms/renderer/cookiecutter.py
@@ -46,6 +46,28 @@ class CookiecutterRenderer(BaseRenderer):
         t.append(": ")
         return t
 
+    def render_summary(self, user_answers: dict[str, Any]) -> bool:
+        """Display a cookiecutter-style summary and ask for confirmation.
+
+        :param user_answers: Answers actively provided by the user.
+        :return: ``True`` to proceed, ``False`` to restart.
+        """
+        self._console.print()
+        self._console.print("  [bold cyan]Review your answers[/]")
+        for key, value in user_answers.items():
+            question = self._question_for_key(key)
+            title = question.title if question else key
+            display = self._summary_display_value(question, value)
+            self._console.print(f"  {escape(title)}: [bold]{escape(str(display))}[/]")
+        self._console.print()
+        while True:
+            value = self._console.input("  Proceed? [Y/n]: ").strip().lower()
+            if not value or value in ("y", "yes"):
+                return True
+            if value in ("n", "no"):
+                return False
+            self._console.print("  [red]Please enter y or n.[/]")
+
     def _validation_error(self, question: BaseQuestion, message: str | None) -> None:
         """Print an error when the validator rejects the user's answer.
 

--- a/src/tui_forms/renderer/noinput.py
+++ b/src/tui_forms/renderer/noinput.py
@@ -18,15 +18,34 @@ class NoInputRenderer(BaseRenderer):
     name: str = "noinput"
     _user_provided: bool = False
 
-    def render(self, initial_answers: dict[str, Any] | None = None) -> dict[str, Any]:
+    def render(
+        self,
+        initial_answers: dict[str, Any] | None = None,
+        *,
+        confirm: bool = False,
+    ) -> dict[str, Any]:
         """Process the form using pre-populated answers and return the result.
+
+        The *confirm* parameter is accepted for API compatibility but has no
+        effect: ``NoInputRenderer`` is non-interactive and never shows a
+        summary screen.
 
         :param initial_answers: Answers from a previous render() call.
             These are seeded into the form before questions are processed,
             so they take priority over schema defaults.
+        :param confirm: Ignored.  ``NoInputRenderer`` always proceeds without
+            confirmation.
         :return: A flat dict mapping each question key to its answer.
         """
-        return super().render(initial_answers)
+        return super().render(initial_answers, confirm=confirm)
+
+    def render_summary(self, user_answers: dict[str, Any]) -> bool:
+        """Always return ``True``; no summary is shown in non-interactive mode.
+
+        :param user_answers: Unused.
+        :return: Always ``True``.
+        """
+        return True
 
     def _dispatch(self, question: form.BaseQuestion) -> Any:
         """Dispatch to the appropriate ask method and raise on validation failure.

--- a/src/tui_forms/renderer/rich.py
+++ b/src/tui_forms/renderer/rich.py
@@ -2,6 +2,7 @@ from rich import box
 from rich.console import Console
 from rich.console import Group
 from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
 from tui_forms.form import BaseQuestion
 from tui_forms.form import Form
@@ -111,7 +112,8 @@ class RichRenderer(BaseRenderer):
         :raises _GoBackRequest: When the user enters the back command.
         """
         default_str = str(default) if default is not None else ""
-        default_hint = f" [dim][{default_str}][/]" if default_str else ""
+        escaped = default_str.replace("[", "\\[") if default_str else ""
+        default_hint = f" [dim]\\[{escaped}][/]" if escaped else ""
         prompt_row = Text.from_markup(f"[bold]Default[/]{default_hint}:")
         body_rows: list[Text] = [Text(""), prompt_row]
         if back_hint := self._back_hint():
@@ -198,6 +200,32 @@ class RichRenderer(BaseRenderer):
                     return options[idx]["const"]
             self._error_line("Invalid choice. Please enter a valid number.")
 
+    def render_summary(self, user_answers: dict[str, Any]) -> bool:
+        """Display a Rich-styled summary table and ask for confirmation.
+
+        :param user_answers: Answers actively provided by the user.
+        :return: ``True`` to proceed, ``False`` to restart.
+        """
+        table = Table(show_header=False, box=box.SIMPLE, padding=(0, 1))
+        table.add_column("Question", style="bold")
+        table.add_column("Answer")
+        for key, value in user_answers.items():
+            question = self._question_for_key(key)
+            title = question.title if question else key
+            display = self._summary_display_value(question, value)
+            table.add_row(title, display)
+        self._console.print()
+        self._console.print(
+            Panel(table, title="Review your answers", title_align="left")
+        )
+        while True:
+            value = self._console.input("\nProceed? [Y/n]: ").strip().lower()
+            if not value or value in ("y", "yes"):
+                return True
+            if value in ("n", "no"):
+                return False
+            self._console.print("[red]Please enter y or n.[/]")
+
     def _ask_multiple(self, question: BaseQuestion, default: Any, prefix: str) -> list:
         """Ask a multiple-choice question with options listed inside the panel.
 
@@ -219,7 +247,10 @@ class RichRenderer(BaseRenderer):
                 )
             else:
                 rows.append(Text.from_markup(f"  [cyan]{i}[/]. {opt['title']}"))
-        selection_prompt = "[bold]Selection[/] [dim](numbers, or enter for default)[/]:"
+        selection_prompt = (
+            "[bold]Selection[/]"
+            " [dim](comma-separated numbers, or enter for default)[/]:"
+        )
         rows.append(Text(""))
         rows.append(Text.from_markup(selection_prompt))
         if back_hint := self._back_hint():

--- a/tests/renderer/test_summary.py
+++ b/tests/renderer/test_summary.py
@@ -1,0 +1,354 @@
+"""Tests for the summary/confirmation screen (confirm=True on render()).
+
+The default render_summary() implementation lives on BaseRenderer and uses
+plain print/input, so these tests exercise it through StdlibRenderer.
+"""
+
+from tui_forms import form
+from tui_forms.renderer.noinput import NoInputRenderer
+from tui_forms.renderer.stdlib import StdlibRenderer
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_form(*questions: form.BaseQuestion) -> form.Form:
+    """Build a minimal Form from positional questions."""
+    return form.Form(title="Test", description="", questions=list(questions))
+
+
+def render_with_confirm(
+    frm: form.Form, question_inputs: list[str], summary_inputs: list[str]
+) -> dict[str, Any]:
+    """Render *frm* with confirm=True, using separate input lists for
+    the question phase and the summary confirmation phase."""
+    all_inputs = question_inputs + summary_inputs
+    with patch("builtins.input", side_effect=all_inputs), patch("builtins.print"):
+        return StdlibRenderer(frm).render(confirm=True)
+
+
+# ---------------------------------------------------------------------------
+# confirm=False (default) skips the summary
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_false_does_not_call_render_summary():
+    """When confirm=False, render_summary should never be called."""
+    frm = make_form(
+        form.Question(key="a", type="string", title="A", description="", default="x"),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer.render_summary = MagicMock(return_value=True)
+    with patch("builtins.input", side_effect=[""]), patch("builtins.print"):
+        renderer.render(confirm=False)
+    renderer.render_summary.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# confirm=True — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_true_calls_render_summary_with_user_answers():
+    """When confirm=True, render_summary is called with the user-provided answers."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default="Alice"
+        ),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer.render_summary = MagicMock(return_value=True)
+    with patch("builtins.input", side_effect=[""]), patch("builtins.print"):
+        renderer.render(confirm=True)
+    renderer.render_summary.assert_called_once_with({"name": "Alice"})
+
+
+def test_confirm_true_returns_answers_when_summary_accepts():
+    """Returning True from render_summary should make render() return answers."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default=""
+        ),
+    )
+    result = render_with_confirm(frm, ["Alice"], ["y"])
+    assert result == {"name": "Alice"}
+
+
+def test_confirm_true_loops_when_summary_declines_then_accepts():
+    """Returning False then True from render_summary loops through questions again."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default=""
+        ),
+    )
+    # Inputs are interleaved: question1, summary1, question2, summary2
+    # First pass: answer "wrong", decline summary ("n")
+    # Second pass: answer "correct", accept summary ("y")
+    all_inputs = ["wrong", "n", "correct", "y"]
+    with patch("builtins.input", side_effect=all_inputs), patch("builtins.print"):
+        result = StdlibRenderer(frm).render(confirm=True)
+    assert result == {"name": "correct"}
+
+
+def test_confirm_true_previous_answers_are_defaults_on_restart():
+    """When the user restarts, previous answers appear as defaults."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default=""
+        ),
+    )
+    # Inputs are interleaved: question1, summary1, question2, summary2
+    # First pass: "Alice"; decline ("n").
+    # Second pass: press Enter (accepts "Alice" as default); confirm ("y").
+    all_inputs = ["Alice", "n", "", "y"]
+    with patch("builtins.input", side_effect=all_inputs), patch("builtins.print"):
+        result = StdlibRenderer(frm).render(confirm=True)
+    assert result == {"name": "Alice"}
+
+
+def test_confirm_true_all_questions_retain_answers_on_restart():
+    """When the user restarts, ALL questions retain previous answers, not just Q1."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default=""
+        ),
+        form.Question(
+            key="email", type="string", title="Email", description="", default=""
+        ),
+    )
+    # First pass: "Alice", "alice@example.com"; decline ("n").
+    # Second pass: press Enter for both (accept previous answers); confirm ("y").
+    all_inputs = ["Alice", "alice@example.com", "n", "", "", "y"]
+    with patch("builtins.input", side_effect=all_inputs), patch("builtins.print"):
+        result = StdlibRenderer(frm).render(confirm=True)
+    assert result == {"name": "Alice", "email": "alice@example.com"}
+
+
+def test_confirm_true_mixed_types_retain_answers_on_restart():
+    """All question types retain their answers on restart: string, boolean, choice."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default="default"
+        ),
+        form.QuestionBoolean(
+            key="flag", type="boolean", title="Enable?", description="", default=False
+        ),
+        form.QuestionChoice(
+            key="license",
+            type="string",
+            title="License",
+            description="",
+            default="mit",
+            options=[
+                {"const": "mit", "title": "MIT"},
+                {"const": "gpl", "title": "GPL"},
+            ],
+        ),
+    )
+    # First pass: "Alice", yes, option 2 (gpl); decline ("n").
+    # Second pass: Enter, Enter, Enter (accept all previous answers); confirm ("y").
+    all_inputs = ["Alice", "y", "2", "n", "", "", "", "y"]
+    with patch("builtins.input", side_effect=all_inputs), patch("builtins.print"):
+        result = StdlibRenderer(frm).render(confirm=True)
+    assert result["name"] == "Alice"
+    assert result["flag"] is True
+    assert result["license"] == "gpl"
+
+
+# ---------------------------------------------------------------------------
+# render_summary() default implementation — output
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_prints_question_titles_and_values():
+    """The default render_summary prints each question's title and value."""
+    frm = make_form(
+        form.Question(
+            key="project",
+            type="string",
+            title="Project name",
+            description="",
+            default="",
+        ),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("project", "my-app", user_provided=True)
+    with (
+        patch("builtins.input", return_value="y"),
+        patch("builtins.print") as mock_print,
+    ):
+        renderer.render_summary(renderer._form.user_answers)
+    printed = " ".join(
+        str(c) for call_ in mock_print.call_args_list for c in call_.args
+    )
+    assert "Project name" in printed
+    assert "my-app" in printed
+
+
+def test_render_summary_returns_true_on_yes():
+    """render_summary returns True when the user types 'y'."""
+    frm = make_form(
+        form.Question(key="a", type="string", title="A", description="", default=""),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("a", "val", user_provided=True)
+    with patch("builtins.input", return_value="y"), patch("builtins.print"):
+        result = renderer.render_summary(renderer._form.user_answers)
+    assert result is True
+
+
+def test_render_summary_returns_true_on_empty_input():
+    """render_summary returns True (default yes) when the user presses Enter."""
+    frm = make_form(
+        form.Question(key="a", type="string", title="A", description="", default=""),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("a", "val", user_provided=True)
+    with patch("builtins.input", return_value=""), patch("builtins.print"):
+        result = renderer.render_summary(renderer._form.user_answers)
+    assert result is True
+
+
+def test_render_summary_returns_false_on_no():
+    """render_summary returns False when the user types 'n'."""
+    frm = make_form(
+        form.Question(key="a", type="string", title="A", description="", default=""),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("a", "val", user_provided=True)
+    with patch("builtins.input", return_value="n"), patch("builtins.print"):
+        result = renderer.render_summary(renderer._form.user_answers)
+    assert result is False
+
+
+def test_render_summary_reprompts_on_invalid_input():
+    """render_summary re-prompts when the user enters neither y nor n."""
+    frm = make_form(
+        form.Question(key="a", type="string", title="A", description="", default=""),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("a", "val", user_provided=True)
+    with patch("builtins.input", side_effect=["maybe", "y"]), patch("builtins.print"):
+        result = renderer.render_summary(renderer._form.user_answers)
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# render_summary() display value formatting
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_boolean_shows_yes_no():
+    """Boolean values are shown as 'Yes' or 'No' in the summary."""
+    frm = make_form(
+        form.QuestionBoolean(
+            key="flag", type="boolean", title="Enable?", description="", default=True
+        ),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("flag", True, user_provided=True)
+    with (
+        patch("builtins.input", return_value="y"),
+        patch("builtins.print") as mock_print,
+    ):
+        renderer.render_summary(renderer._form.user_answers)
+    printed = " ".join(
+        str(c) for call_ in mock_print.call_args_list for c in call_.args
+    )
+    assert "Yes" in printed
+
+
+def test_render_summary_choice_shows_option_title():
+    """Choice values are resolved to their option title in the summary."""
+    frm = make_form(
+        form.QuestionChoice(
+            key="license",
+            type="string",
+            title="License",
+            description="",
+            default="mit",
+            options=[
+                {"const": "mit", "title": "MIT License"},
+                {"const": "apache", "title": "Apache 2.0"},
+            ],
+        ),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("license", "mit", user_provided=True)
+    with (
+        patch("builtins.input", return_value="y"),
+        patch("builtins.print") as mock_print,
+    ):
+        renderer.render_summary(renderer._form.user_answers)
+    printed = " ".join(
+        str(c) for call_ in mock_print.call_args_list for c in call_.args
+    )
+    assert "MIT License" in printed
+
+
+def test_render_summary_multiple_shows_comma_separated_titles():
+    """Multiple-choice values are shown as comma-separated option titles."""
+    frm = make_form(
+        form.QuestionMultiple(
+            key="tags",
+            type="array",
+            title="Tags",
+            description="",
+            default=[],
+            options=[
+                {"const": "a", "title": "Alpha"},
+                {"const": "b", "title": "Beta"},
+            ],
+        ),
+    )
+    renderer = StdlibRenderer(frm)
+    renderer._form.start()
+    renderer._form.record("tags", ["a", "b"], user_provided=True)
+    with (
+        patch("builtins.input", return_value="y"),
+        patch("builtins.print") as mock_print,
+    ):
+        renderer.render_summary(renderer._form.user_answers)
+    printed = " ".join(
+        str(c) for call_ in mock_print.call_args_list for c in call_.args
+    )
+    assert "Alpha" in printed
+    assert "Beta" in printed
+
+
+# ---------------------------------------------------------------------------
+# NoInputRenderer — render_summary always returns True
+# ---------------------------------------------------------------------------
+
+
+def test_noinput_render_summary_always_returns_true():
+    """NoInputRenderer.render_summary always returns True without I/O."""
+    frm = make_form(
+        form.Question(key="a", type="string", title="A", description="", default="x"),
+    )
+    renderer = NoInputRenderer(frm)
+    assert renderer.render_summary({}) is True
+
+
+def test_noinput_confirm_true_does_not_loop():
+    """NoInputRenderer with confirm=True should complete in one pass."""
+    frm = make_form(
+        form.Question(
+            key="name", type="string", title="Name", description="", default="Alice"
+        ),
+    )
+    renderer = NoInputRenderer(frm)
+    result = renderer.render(confirm=True)
+    assert result == {"name": "Alice"}


### PR DESCRIPTION
## Summary

Adds a summary/confirmation screen to the form wizard. Pass `confirm=True` to `render()` to display all user-provided answers before finishing; the user can confirm to proceed or decline to restart with prior answers pre-populated as defaults.

- `BaseRenderer.render_summary()` with plain-text fallback; overridden in `RichRenderer` and `CookiecutterRenderer` with styled Rich tables
- `NoInputRenderer.render_summary()` always returns `True` (no user to prompt)
- Demo CLI enables confirm by default; opt out with `--no-confirm`
- Fix: Rich markup escaping — bracket-wrapped defaults like `[plone]` were silently swallowed by `Text.from_markup()`
- Fix: clarify comma-separated input hint for multiple-choice questions
- 17 new tests, documentation updates (tutorial, how-to guide, API reference)

## Test plan

- [x] All 361 tests pass
- [x] `make format` clean
- [x] `make lint` clean
- [x] `make lint-mypy` clean
- [x] Manual test: `uv run formdemo rich showcase` → answer all → decline summary → verify previous answers shown as defaults → confirm

Closes #9