### PR TITLE
Fix condition evaluation and user_answers when root_key is used

### DIFF
--- a/news/fix-root-key-logic.bugfix
+++ b/news/fix-root-key-logic.bugfix
@@ -1,0 +1,2 @@
+Fixed `Form.is_active` and `Form.user_answers` to correctly handle `root_key` nesting. Conditional questions now work properly when answers are nested under a common root key.
+Improved `renderer.render()` to support un-nested `initial_answers` by automatically recording them under the `root_key` if one is defined.

--- a/src/tui_forms/form/form.py
+++ b/src/tui_forms/form/form.py
@@ -26,8 +26,8 @@ class Form:
         """Return question data answered by the user."""
         answers = self.answers
         if root_key := self.root_key:
-            answers = answers[root_key]
-        user_answers = {k: answers[k] for k in self._user_answers}
+            answers = answers.get(root_key, {})
+        user_answers = {k: answers[k] for k in self._user_answers if k in answers}
         return user_answers
 
     @property
@@ -48,8 +48,11 @@ class Form:
         """
         if question.condition is None:
             return True
+        answers = self.answers
+        if self.root_key:
+            answers = answers.get(self.root_key, {})
         return all(
-            self.answers.get(cond["key"]) == cond["value"]
+            answers.get(cond["key"]) == cond["value"]
             for cond in question.condition
         )
 

--- a/src/tui_forms/form/question.py
+++ b/src/tui_forms/form/question.py
@@ -63,6 +63,9 @@ class BaseQuestion:
         current_value = (answers.get(root_key, {}) if root_key else answers).get(
             key, _NOVALUE
         )
+        import sys
+        if key == 'thumbor':
+             print(f"DEBUG: _render_variable({key}): root_key='{root_key}', found={current_value != _NOVALUE}, value={current_value}", file=sys.stderr)
         if current_value is _NOVALUE:
             value = template.render_variable(env, value, answers)
         else:

--- a/src/tui_forms/parser.py
+++ b/src/tui_forms/parser.py
@@ -273,6 +273,8 @@ def _build_subquestions(
         seen_keys.add(sub_key)
 
     for allof_item in prop_schema.get("allOf", []):
+        import sys
+        print(f"DEBUG: Processing allOf item: {allof_item}", file=sys.stderr)
         then = allof_item.get("then")
         if not then:
             continue

--- a/src/tui_forms/renderer/base.py
+++ b/src/tui_forms/renderer/base.py
@@ -66,7 +66,14 @@ class BaseRenderer(ABC):
         while True:
             self._form.start()
             if current_initial:
-                self._form.answers.update(current_initial)
+                # If root_key is set, and current_initial is not already nested
+                # under it, we should record them properly so they end up
+                # in the right place for is_active and other logic.
+                if self._form.root_key and self._form.root_key not in current_initial:
+                    for k, v in current_initial.items():
+                        self._form.record(k, v)
+                else:
+                    self._form.answers.update(current_initial)
             self._ask_questions(self._form.questions)
             # Remove stale answers for questions that became inactive
             # (e.g. conditional questions whose gating answer changed
@@ -230,6 +237,7 @@ class BaseRenderer(ABC):
                     history.pop()
                 continue
             self._form.record(next_q.key, answer, user_provided=self._user_provided)
+            # print(f"DEBUG: Recorded {next_q.key}={answer} (root_key={self._form.root_key})")
             history.append(next_q.key)
 
     def _dispatch(self, question: form.BaseQuestion) -> Any:

--- a/tests/form/test_form_root_key.py
+++ b/tests/form/test_form_root_key.py
@@ -1,0 +1,41 @@
+from tui_forms.form.form import Form
+from tui_forms.form.question import Question
+import pytest
+
+def test_is_active_with_root_key():
+    """Verify that is_active correctly finds answers when a root_key is used."""
+    q_cond = Question(
+        key="thumbor",
+        type="boolean",
+        title="Thumbor",
+        description="",
+        default=False,
+        condition=[{"key": "postgres", "value": True}]
+    )
+    
+    # Without root_key
+    frm1 = Form(title="T", description="", questions=[q_cond])
+    frm1.record("postgres", True)
+    assert frm1.is_active(q_cond) is True
+    
+    # With root_key (e.g. cookiecutter)
+    frm2 = Form(title="T", description="", questions=[q_cond], root_key="cookiecutter")
+    frm2.record("postgres", True)
+    # This is expected to FAIL before the fix
+    assert frm2.is_active(q_cond) is True
+
+def test_user_answers_with_root_key():
+    """Verify that user_answers correctly retrieves answers when a root_key is used."""
+    q = Question(key="a", type="string", title="A", description="", default="")
+    frm = Form(title="T", description="", questions=[q], root_key="cookiecutter")
+    
+    frm.record("a", "val", user_provided=True)
+    
+    # This should return {'a': 'val'}
+    # Before fix it might raise KeyError or return wrong data depending on implementation
+    assert frm.user_answers == {"a": "val"}
+
+def test_user_answers_empty_with_root_key():
+    """Verify that user_answers doesn't crash when no answers recorded yet with root_key."""
+    frm = Form(title="T", description="", questions=[], root_key="cookiecutter")
+    assert frm.user_answers == {}


### PR DESCRIPTION
Found a bug in `Form.is_active` and `Form.user_answers` where they were not aware of `root_key` nesting. 
When a `root_key` is defined (like `cookiecutter` in `cookieplone`), all answers are nested under that key.
The engine was looking for answers at the top level, causing all conditions to fail and `user_answers` to be empty or raise `KeyError`.

This PR:
- Makes `is_active` look inside `root_key` for gating answers.
- Makes `user_answers` retrieve values from the nested dict.
- Updates `BaseRenderer.render` to automatically record un-nested `initial_answers` under the `root_key` if one exists.
- Adds regression tests in `tests/form/test_form_root_key.py`.

This is required for conditional questions in `cookieplone` to work properly.