### PR TITLE
Fix confirmation summary listing answers out of order (#29)

### DIFF
--- a/news/29.bugfix
+++ b/news/29.bugfix
@@ -1,0 +1,1 @@
+Confirmation summary now lists answers in the order the questions were asked, instead of an arbitrary order. @ericof

--- a/src/tui_forms/form/form.py
+++ b/src/tui_forms/form/form.py
@@ -19,7 +19,7 @@ class Form:
     answers: dict[str, Any] = field(default_factory=dict)
     root_key: str = ""
     _question_index: int = field(default=0, init=False, repr=False)
-    _user_answers: set[str] = field(default_factory=set, init=False, repr=False)
+    _user_answers: list[str] = field(default_factory=list, init=False, repr=False)
 
     @property
     def user_answers(self) -> dict[str, Any]:
@@ -80,8 +80,8 @@ class Form:
                 answers[self.root_key] = {}
             answers = answers[self.root_key]
         answers[key] = value
-        if user_provided:
-            self._user_answers.add(key)
+        if user_provided and key not in self._user_answers:
+            self._user_answers.append(key)
 
     def set_question_index(self, n: int) -> None:
         """Set the question index directly.
@@ -99,7 +99,8 @@ class Form:
         if self.root_key:
             answers = answers.get(self.root_key, {})
         answers.pop(key, None)
-        self._user_answers.discard(key)
+        if key in self._user_answers:
+            self._user_answers.remove(key)
 
     def iter_all(self) -> Iterator[BaseQuestion]:
         """Yield every question and its subquestions depth-first.

--- a/tests/form/test_form.py
+++ b/tests/form/test_form.py
@@ -156,7 +156,24 @@ def test_start_clears_user_answers(simple_form):
     """start() should clear _user_answers alongside answers."""
     simple_form.record("a", "hello", user_provided=True)
     simple_form.start()
-    assert simple_form._user_answers == set()
+    assert simple_form._user_answers == []
+
+
+def test_user_answers_preserves_record_order(simple_form):
+    """user_answers must reflect the order questions were answered, not hash order."""
+    # Record in a deliberately non-alphabetical order.
+    for key in ("delta", "alpha", "charlie", "bravo"):
+        simple_form.record(key, key, user_provided=True)
+    assert list(simple_form.user_answers) == ["delta", "alpha", "charlie", "bravo"]
+
+
+def test_record_user_provided_twice_keeps_first_position(simple_form):
+    """Re-recording an answer keeps its original position and avoids duplicates."""
+    simple_form.record("a", "first", user_provided=True)
+    simple_form.record("b", "x", user_provided=True)
+    simple_form.record("a", "updated", user_provided=True)
+    assert simple_form._user_answers == ["a", "b"]
+    assert list(simple_form.user_answers) == ["a", "b"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/renderer/test_noinput.py
+++ b/tests/renderer/test_noinput.py
@@ -316,7 +316,7 @@ def test_noinput_user_answers_is_empty_after_render():
         )
     )
     NoInputRenderer(frm).render()
-    assert frm._user_answers == set()
+    assert frm._user_answers == []
 
 
 def test_validation_error_raises_with_message():

--- a/tests/renderer/test_stdlib.py
+++ b/tests/renderer/test_stdlib.py
@@ -475,7 +475,7 @@ def test_interactive_renderer_populates_user_answers(make_form):
     })
     with patch("builtins.input", side_effect=["x", "y"]), patch("builtins.print"):
         StdlibRenderer(frm).render()
-    assert frm._user_answers == {"a", "b"}
+    assert frm._user_answers == ["a", "b"]
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1959,7 +1959,7 @@ wheels = [
 
 [[package]]
 name = "tui-forms"
-version = "1.0.0b1"
+version = "1.0.0b2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

The end-of-form confirmation summary listed the user's answers in an arbitrary order rather than the order the questions were asked.

The root cause was that user-provided answer keys were tracked in a `set`, which has no defined iteration order. Although Python dicts preserve insertion order, the `user_answers` property built its dict by iterating that set — so the order followed the set's hash-based ordering, not the asking order.

## Change

- `Form._user_answers` is now an order-preserving `list[str]` instead of a `set[str]`.
- `record()` appends keys in asking order (with a dedup guard); `unrecord()` removes safely.
- `Form.user_answers` now yields answers in question order automatically. The renderer-facing API is unchanged — it still returns a `dict[str, Any]`.

## Tests

- Added a regression test asserting `user_answers` follows record order (not hash/sorted order).
- Added a test that re-recording an answer keeps its original position without duplicating.
- Updated three existing assertions that compared `_user_answers` against set literals.

## Verification

- 424 tests pass
- `ruff format` + `ruff check` clean
- `mypy src` clean

Closes #29